### PR TITLE
Add hideCanopy() function and user token

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -17,7 +17,11 @@
 const bootstrap = (): void => {
   /* no op */
 };
-const completeUser = { userId: 'COMPLETE', displayName: 'canopy' };
+const completeUser = {
+  userId: 'COMPLETE',
+  displayName: 'canopy',
+  token: 'canopy.token'
+};
 const minimalUser = { userId: 'MINIMAL' };
 
 // In order to prevent the need to overwrite the window interface,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { submitBatchList } from './submitter';
 interface User {
   userId: string;
   displayName?: string;
+  token?: string;
 }
 
 interface KeyPair {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,11 @@ interface RegisterConfigSapling {
     bootstrapFunction: () => void
   ): void;
 }
+
+interface HideCanopy {
+  (): void;
+}
+
 interface Canopy {
   registerApp: RegisterApp;
   registerConfigSapling: RegisterConfigSapling;
@@ -71,6 +76,7 @@ interface Canopy {
   setKeys: SetKeys;
   getKeys: GetKeys;
   getSharedConfig: GetSharedConfig;
+  hideCanopy: HideCanopy;
 }
 
 function assertAndGetWindowCanopy(): Canopy {
@@ -95,5 +101,6 @@ export const {
   setUser,
   setKeys,
   getKeys,
-  getSharedConfig
+  getSharedConfig,
+  hideCanopy
 }: Canopy = canopy;


### PR DESCRIPTION
Adds a hideCanopy() function to saplingjs. The implementation of this should hide the canopy nav element.

Adds a token field to users so that an auth token can be fetched from saplings.