### PR TITLE
Add Davey Newhall as codeowner and maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @davececchi @dplumb94 @eloaverona @jsmitchell @peterschwarz @ltseeley @rbuysse @RyanLassigBanks @shannynalayna @vaporos @zapplebee
+*       @agunde406 @chenette @davececchi @dnewh @dplumb94 @eloaverona @jsmitchell @peterschwarz @ltseeley @rbuysse @RyanLassigBanks @shannynalayna @vaporos @zapplebee

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@
 | Anne Chenette | chenette |
 | Darian Plumb | dplumb94 |
 | Dave Cecchi | davececchi |
+| Davey Newhall | dnewh |
 | Eloá Franca Verona | eloaverona |
 | James Mitchell | jsmitchell |
 | Logan Seeley | ltseeley |


### PR DESCRIPTION
Signed-off-by: Darian Plumb <dplumb@bitwise.io>