### PR TITLE
Fix build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,4 @@
 **/coverage
 **/build
 **/dist
+**/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 **/.pnp
 **/.pnp.js
 **/yarn.lock
+**/package-lock.json
 
 #testing
 **/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ FROM node:lts-alpine
 
 WORKDIR /saplingjs
 
-COPY package*.json ./
-
-RUN yarn install
-
 COPY . .
+
+RUN npm install


### PR DESCRIPTION
This fixes the build by copying the source code into the dockerfile before running `npm install`. This was causing the build to fail because the prepare script builds the code on installation.