### PR TITLE
Update README with link to splinter.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,8 @@ limitations under the License. -->
 
 # SaplingJS
 
-SaplingJS is a library for building Saplings. Saplings are UI plugins for Canopy
-applications.
+SaplingJS is a library for building saplings, which are UI plugins for Canopy
+applications. Saplings are designed to work with Splinter.
+
+See [splinter.dev](https://www.splinter.dev/) for Splinter documentation,
+release notes, and community information.


### PR DESCRIPTION
Also adds a sentence to mention Splinter, so that the following "See splinter.dev"
makes sense.

Signed-off-by: Anne Chenette <chenette@bitwise.io>