### PR TITLE
Add additional .env file

### DIFF
--- a/docker/compose/.env
+++ b/docker/compose/.env
@@ -1,0 +1,17 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ISOLATION_ID=latest
+DISTRO=bionic
+REPO_VERSION=0.3.12-dev

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,17 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ISOLATION_ID=latest
+DISTRO=bionic
+REPO_VERSION=0.3.12-dev


### PR DESCRIPTION
As of version 1.28.0, Docker Compose expects .env files to reside in the same
directory as the compose files or to have their path specicified with an
additional argument to the compose command. Duplicating the .env files
whereever they're needed was deemed to be the least disruptive solution.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>